### PR TITLE
broom.mixed fix for gamlss model output

### DIFF
--- a/R/ebb_fit_prior.R
+++ b/R/ebb_fit_prior.R
@@ -171,7 +171,7 @@ ebb_fit_prior_ <- function(tbl, x, n,
                             data = tbl, family = fam, ...)
     )
 
-    parameters <- broom::tidy(fit)
+    parameters <- broom.mixed::tidy(fit)
     colnames(parameters)[colnames(parameters) == ".rownames"] <- "term" # for broom.mixed
     parameters
   }


### PR DESCRIPTION
fixed the "$ operator is invalid for atomic vectors" error received when estimating the eb_prior using method = 'gamlss' w/ or w/o using mu_predictors